### PR TITLE
Allow Value to compare against other strings for convenience.

### DIFF
--- a/django_enumfield/enum.py
+++ b/django_enumfield/enum.py
@@ -62,6 +62,8 @@ class Enum(object):
         def __eq__(self, other):
             if other and isinstance(other, Enum.Value):
                 return self.value == other.value
+            elif isinstance(other, basestring):
+                return type(other)(self.value) == other
             else:
                 raise TypeError('Can not compare Enum with %s' % other.__class__.__name__)
 


### PR DESCRIPTION
Since enum values are string comparable anyway, allow comparing the two.
