### PR TITLE
Restore original migration behavior

### DIFF
--- a/django_enumfield/db/fields.py
+++ b/django_enumfield/db/fields.py
@@ -16,6 +16,8 @@ class EnumField(six.with_metaclass(models.SubfieldBase, models.IntegerField)):
         kwargs['choices'] = enum.choices()
         if not default:
             kwargs['default'] = enum.default()
+        if 'db_index' not in kwargs:
+            kwargs['db_index'] = True
         self.enum = enum
         models.IntegerField.__init__(self, *args, **kwargs)
 

--- a/django_enumfield/db/fields.py
+++ b/django_enumfield/db/fields.py
@@ -79,5 +79,7 @@ class EnumField(six.with_metaclass(models.SubfieldBase, models.IntegerField)):
 
     def deconstruct(self):
         name, path, args, kwargs = super(EnumField, self).deconstruct()
-        kwargs['enum'] = self.enum
+        path = "django.db.models.fields.IntegerField"
+        if 'choices' in kwargs:
+            del kwargs['choices']
         return name, path, args, kwargs

--- a/django_enumfield/db/fields.py
+++ b/django_enumfield/db/fields.py
@@ -16,8 +16,6 @@ class EnumField(six.with_metaclass(models.SubfieldBase, models.IntegerField)):
         kwargs['choices'] = enum.choices()
         if not default:
             kwargs['default'] = enum.default()
-        if 'db_index' not in kwargs:
-            kwargs['db_index'] = True
         self.enum = enum
         models.IntegerField.__init__(self, *args, **kwargs)
 

--- a/django_enumfield/tests/models.py
+++ b/django_enumfield/tests/models.py
@@ -50,7 +50,7 @@ class BeerState(Enum):
 
 class Beer(models.Model):
     style = EnumField(BeerStyle)
-    state = EnumField(BeerState, null=True, db_index=False)
+    state = EnumField(BeerState, null=True)
 
 
 class LabelBeer(Enum):

--- a/django_enumfield/tests/models.py
+++ b/django_enumfield/tests/models.py
@@ -50,7 +50,7 @@ class BeerState(Enum):
 
 class Beer(models.Model):
     style = EnumField(BeerStyle)
-    state = EnumField(BeerState, null=True)
+    state = EnumField(BeerState, null=True, db_index=False)
 
 
 class LabelBeer(Enum):


### PR DESCRIPTION
Adjusted the `deconstruct()` and `__init__()` to get the same migration definition as South in pre-1.7.

Tack!