### PR TITLE
always respect given default

### DIFF
--- a/django_enumfield/db/fields.py
+++ b/django_enumfield/db/fields.py
@@ -12,9 +12,8 @@ class EnumField(six.with_metaclass(models.SubfieldBase, models.IntegerField)):
     """
 
     def __init__(self, enum, *args, **kwargs):
-        default = kwargs.get('default')
         kwargs['choices'] = enum.choices()
-        if not default:
+        if 'default' not in kwargs:
             kwargs['default'] = enum.default()
         self.enum = enum
         models.IntegerField.__init__(self, *args, **kwargs)

--- a/django_enumfield/tests/test_enum.py
+++ b/django_enumfield/tests/test_enum.py
@@ -17,6 +17,8 @@ class EnumFieldTest(TestCase):
         self.assertEqual(len(PersonStatus.choices()), len(field.choices))
         field = EnumField(PersonStatus, default=PersonStatus.ALIVE)
         self.assertEqual(field.default, PersonStatus.ALIVE)
+        field = EnumField(PersonStatus, default=None)
+        self.assertEqual(field.default, None)
 
     def test_enum_field_save(self):
         # Test model with EnumField WITHOUT _transitions


### PR DESCRIPTION
Hi, I'd like to be able specify ``default=None`` but this wasn't being respected by the old code. Do you think it makes sense in an Enum context? Essentially what I am saying is that it is an error for the user to not specifically choose a value.