### PR TITLE
If a field is nullable, it should provide an empty choice.

### DIFF
--- a/django_enumfield/db/fields.py
+++ b/django_enumfield/db/fields.py
@@ -60,7 +60,7 @@ class EnumField(six.with_metaclass(models.SubfieldBase, models.IntegerField)):
         defaults = {'widget': forms.Select,
                     'form_class': forms.TypedChoiceField,
                     'coerce': int,
-                    'choices': self.enum.choices()}
+                    'choices': self.enum.choices(blank=self.blank)}
         defaults.update(kwargs)
         return super(EnumField, self).formfield(**defaults)
 

--- a/django_enumfield/enum.py
+++ b/django_enumfield/enum.py
@@ -66,12 +66,15 @@ class Enum(six.with_metaclass(EnumType)):
             return path, (self.name, self.value, self.label, self.enum_type), {}
 
     @classmethod
-    def choices(cls):
+    def choices(cls, blank=False):
         """ Choices for Enum
         :return: List of tuples (<value>, <human-readable value>)
         :rtype: list
         """
-        return sorted([(key, value) for key, value in cls.values.items()], key=lambda x: x[0])
+        choices = sorted([(key, value) for key, value in cls.values.items()], key=lambda x: x[0])
+        if blank:
+            choices.insert(0, ('', Enum.Value('', None, '', cls)))
+        return choices
 
     @classmethod
     def default(cls):

--- a/django_enumfield/tests/models.py
+++ b/django_enumfield/tests/models.py
@@ -50,7 +50,7 @@ class BeerState(Enum):
 
 class Beer(models.Model):
     style = EnumField(BeerStyle)
-    state = EnumField(BeerState, null=True)
+    state = EnumField(BeerState, null=True, blank=True)
 
 
 class LabelBeer(Enum):

--- a/django_enumfield/tests/test_enum.py
+++ b/django_enumfield/tests/test_enum.py
@@ -96,6 +96,24 @@ class EnumFieldTest(TestCase):
         form = PersonForm(request.POST, instance=person)
         self.assertFalse(form.is_valid())
 
+    def test_enum_field_nullable_field(self):
+        class BeerForm(ModelForm):
+            class Meta:
+                model = Beer
+
+        form = BeerForm()
+
+        self.assertEqual(len(form.fields['style'].choices), 3)
+        self.assertEqual(form.fields['style'].choices[0][1].label, 'LAGER')
+        self.assertEqual(form.fields['style'].choices[1][1].label, 'STOUT')
+        self.assertEqual(form.fields['style'].choices[2][1].label, 'WEISSBIER')
+
+        self.assertEqual(len(form.fields['state'].choices), 4)
+        self.assertEqual(form.fields['state'].choices[0][1].label, '')
+        self.assertEqual(form.fields['state'].choices[1][1].label, 'FIZZY')
+        self.assertEqual(form.fields['state'].choices[2][1].label, 'STALE')
+        self.assertEqual(form.fields['state'].choices[3][1].label, 'EMPTY')
+
 
 class EnumTest(TestCase):
     def test_label(self):


### PR DESCRIPTION
A nullable field shouldn't force a choice to be selected. There are many ways this could be achieved; this is just one possibility.