### PR TITLE
Add file to source tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include AUTHORS
 include LICENSE
 include README.rst
+include run_tests.py


### PR DESCRIPTION
In other case this file is missing if you try to build a debian
package from the original sources which are downloaded from pypi.