### PR TITLE
Passing a string_type to Enum.get should return None on error

### DIFF
--- a/django_enumfield/enum.py
+++ b/django_enumfield/enum.py
@@ -109,7 +109,10 @@ class Enum(six.with_metaclass(EnumType)):
         :rtype: Enum.Value
         """
         if isinstance(name_or_numeric, six.string_types):
-            name_or_numeric = getattr(cls, name_or_numeric.upper())
+            try:
+                name_or_numeric = getattr(cls, name_or_numeric.upper())
+            except AttributeError:
+                return None
 
         return cls.values.get(name_or_numeric)
 


### PR DESCRIPTION
.. as per the documentation. It currently raises AttributeError

Signed-off-by: Chris Lamb chris@chris-lamb.co.uk
