### PR TITLE
Added tests to show errors in django 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
 matrix:
   exclude:
     - python: 3.3
-      env: DJANGO==1.9rc1
+      env: DJANGO==1.9
     - python: 3.3
       env: DJANGO==1.10
     - python: 3.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,15 @@ env:
   - DJANGO=1.6
   - DJANGO=1.7
   - DJANGO=1.8
-  - DJANGO==1.9rc1
+  - DJANGO=1.9
+  - DJANGO=1.10
 
 matrix:
   exclude:
     - python: 3.3
       env: DJANGO==1.9rc1
+    - python: 3.3
+      env: DJANGO==1.10
     - python: 3.5
       env: DJANGO=1.6
     - python: 3.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,9 @@ env:
 matrix:
   exclude:
     - python: 3.3
-      env: DJANGO==1.9
+      env: DJANGO=1.9
     - python: 3.3
-      env: DJANGO==1.10
+      env: DJANGO=1.10
     - python: 3.5
       env: DJANGO=1.6
     - python: 3.5

--- a/django_enumfield/tests/models.py
+++ b/django_enumfield/tests/models.py
@@ -30,6 +30,7 @@ class PersonStatus(Enum):
 
 
 class Person(models.Model):
+    example = models.CharField(max_length=100, default="foo")
     status = EnumField(PersonStatus, default=PersonStatus.ALIVE)
 
     def save(self, *args, **kwargs):

--- a/django_enumfield/tests/test_enum.py
+++ b/django_enumfield/tests/test_enum.py
@@ -83,6 +83,24 @@ class EnumFieldTest(TestCase):
         self.assertEqual(beer.state, None)
         self.assertEqual(beer.style, BeerStyle.STOUT)
 
+    def test_enum_field_modelform_create(self):
+        class PersonForm(ModelForm):
+            class Meta:
+                model = Person
+                fields = ('status',)
+
+        request_factory = RequestFactory()
+        request = request_factory.post('', data={'status': '2'})
+        form = PersonForm(request.POST)
+        self.assertTrue(isinstance(form.fields['status'], TypedChoiceField))
+        self.assertTrue(form.is_valid())
+        person = form.save()
+        self.assertTrue(person.status, PersonStatus.DEAD)
+
+        request = request_factory.post('', data={'status': '99'})
+        form = PersonForm(request.POST, instance=person)
+        self.assertFalse(form.is_valid())
+
     def test_enum_field_modelform(self):
         person = Person.objects.create()
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist = py27_django15, py27_django16, py27_django17, py27_django18,
-          py33_django15, py33_django16, py33_django17, py33_django18,
-          py34_django15, py34_django16, py34_django17, py34_django18
+          py34_django15, py34_django16, py34_django17, py34_django18,
+          py35_django19, py35_django110
 
 [testenv]
 commands = {envpython} setup.py test
@@ -65,3 +65,14 @@ deps =
 basepython = python3.4
 deps =
     Django==1.8.1
+
+
+[testenv:py35_django19]
+basepython = python3.5
+deps =
+    Django==1.9.0
+
+[testenv:py35_django110]
+basepython = python3.5
+deps =
+    Django==1.10.0


### PR DESCRIPTION
Adding this PR to show bug in `django-enumfield` in the newly released `Django==1.10`. 

Problem was (most probably) caused by this changeset in Django repository: https://github.com/django/django/commit/7f51876f99851fdc3fef63aecdfbcffa199c26b9, and especially by the change to `get_deferred_fields`.

Let's consider this model: 

```
class Person(models.Model):
    example = models.CharField(max_length=100, default="foo")
    status = EnumField(PersonStatus, default=PersonStatus.ALIVE)
```

`EnumField` users Python properties under the hood, that is: `Person.status` is a property, this causes check used by `get_deferred_fields` to always treat `status` as a deffered field (that is always `"status" not in self.__dict__`). This causes all kinds of fun, for example excludes status from fields that are updated. 
