### PR TITLE
Fix initial form value

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ matrix:
     - env: ENV=py37-django22
       python: 3.7
 
-    - env: ENV=coverage
+    - env: ENV=checks
       python: 3.7
 
 install:

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,12 @@ isort:
 black:
 	black django_enumfield run_tests.py setup.py
 
+.PHONY: black-check
+black-check:
+	black --check django_enumfield run_tests.py setup.py
+
+.PHONY: checks
+checks: flake8 mypy black-check
 
 .PHONY: format
 format: black isort

--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ The `Enum`-class can also be used without the `EnumField`. This is very useful i
 ```python
 from django import forms
 from django_enumfield import enum
+from django_enumfield.forms.fields import EnumChoiceField
 
 
 class GenderEnum(enum.Enum):
@@ -181,7 +182,7 @@ class GenderEnum(enum.Enum):
 
 
 class PersonForm(forms.Form):
-    gender = forms.TypedChoiceField(choices=GenderEnum.choices(), coerce=int)
+    gender = EnumChoiceField(GenderEnum)
 ```
 
 Rendering `PersonForm` in a template will generate a select-box with "Male" and "Female" as option labels for the gender field.

--- a/django_enumfield/db/fields.py
+++ b/django_enumfield/db/fields.py
@@ -8,6 +8,7 @@ from django.utils.functional import curry
 from django.utils.translation import ugettext
 
 from django_enumfield.exceptions import InvalidStatusOperationError
+from django_enumfield.forms.fields import EnumChoiceField
 
 from .. import validators
 
@@ -64,6 +65,8 @@ class EnumField(models.IntegerField):
 
     def to_python(self, value):
         if value is not None:
+            if isinstance(value, six.text_type) and value.isdigit():
+                value = int(value)
             return self.enum.get(value)
 
     def _setup_validation(self, sender, **kwargs):
@@ -127,8 +130,8 @@ class EnumField(models.IntegerField):
     def formfield(self, **kwargs):
         defaults = {
             "widget": forms.Select,
-            "form_class": forms.TypedChoiceField,
-            "coerce": int,
+            "form_class": EnumChoiceField,
+            "choices_form_class": EnumChoiceField,
             "choices": self.enum.choices(blank=self.blank),
         }
         defaults.update(kwargs)

--- a/django_enumfield/db/fields.py
+++ b/django_enumfield/db/fields.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from functools import partial
 
 from django import forms
 from django.db import models
@@ -128,10 +129,11 @@ class EnumField(models.IntegerField):
         )
 
     def formfield(self, **kwargs):
+        enum_form_class = partial(EnumChoiceField, enum=self.enum)
         defaults = {
             "widget": forms.Select,
-            "form_class": EnumChoiceField,
-            "choices_form_class": EnumChoiceField,
+            "form_class": enum_form_class,
+            "choices_form_class": enum_form_class,
             "choices": self.enum.choices(blank=self.blank),
         }
         defaults.update(kwargs)

--- a/django_enumfield/forms/fields.py
+++ b/django_enumfield/forms/fields.py
@@ -4,9 +4,10 @@ from django import forms
 
 
 class EnumChoiceField(forms.TypedChoiceField):
-    def __init__(self, enum=None, **kwargs):
-        if enum is not None:
-            kwargs.setdefault("choices", enum.choices())
+    def __init__(self, enum, **kwargs):
+        kwargs.setdefault(
+            "choices", enum.choices(blank=not kwargs.get("required", True))
+        )
         kwargs.setdefault("coerce", int)
         super(EnumChoiceField, self).__init__(**kwargs)
         self.enum = enum
@@ -15,3 +16,9 @@ class EnumChoiceField(forms.TypedChoiceField):
         if isinstance(value, NativeEnum):
             return value.value
         return value
+
+    def clean(self, value):
+        value = super(EnumChoiceField, self).clean(value)
+        if value == self.empty_value:
+            return value
+        return self.enum(value)

--- a/django_enumfield/forms/fields.py
+++ b/django_enumfield/forms/fields.py
@@ -1,0 +1,17 @@
+from enum import Enum as NativeEnum
+
+from django import forms
+
+
+class EnumChoiceField(forms.TypedChoiceField):
+    def __init__(self, enum=None, **kwargs):
+        if enum is not None:
+            kwargs.setdefault("choices", enum.choices())
+        kwargs.setdefault("coerce", int)
+        super(EnumChoiceField, self).__init__(**kwargs)
+        self.enum = enum
+
+    def prepare_value(self, value):
+        if isinstance(value, NativeEnum):
+            return value.value
+        return value

--- a/django_enumfield/tests/test_enum.py
+++ b/django_enumfield/tests/test_enum.py
@@ -243,6 +243,19 @@ class EnumFieldTest(TestCase):
         self.assertTrue(form.is_valid(), form.errors)
         self.assertEqual(form.cleaned_data["status"], PersonStatus.ALIVE)
 
+    def test_enum_form_field_not_required(self):
+        class CustomPersonForm(forms.Form):
+            status = EnumChoiceField(PersonStatus, required=False)
+
+        form = CustomPersonForm(
+            data={"status": None}, initial={"status": PersonStatus.DEAD.value}
+        )
+        self.assertEqual(
+            form.fields["status"].choices, PersonStatus.choices(blank=True)
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+        self.assertEqual(form.cleaned_data["status"], six.text_type())
+
 
 class EnumTest(TestCase):
     def test_label(self):

--- a/django_enumfield/tests/test_enum.py
+++ b/django_enumfield/tests/test_enum.py
@@ -1,11 +1,11 @@
 from contextlib import contextmanager
 from os.path import abspath, dirname, exists, join
 
+from django import forms
 from django.core.management import call_command
 from django.db import IntegrityError, connection
 from django.db.backends.sqlite3.base import DatabaseWrapper
 from django.db.models.fields import NOT_PROVIDED
-from django.forms import ModelForm, TypedChoiceField
 from django.test import TestCase
 from django.test.client import RequestFactory
 from django.utils import six
@@ -13,6 +13,7 @@ from django.utils import six
 from django_enumfield.db.fields import EnumField
 from django_enumfield.enum import BlankEnum, Enum
 from django_enumfield.exceptions import InvalidStatusOperationError
+from django_enumfield.forms.fields import EnumChoiceField
 from django_enumfield.tests.models import (
     Beer,
     BeerState,
@@ -59,7 +60,7 @@ def patch_sqlite_connection():
         DatabaseWrapper.disable_constraint_checking = old_disable
 
 
-class PersonForm(ModelForm):
+class PersonForm(forms.ModelForm):
     class Meta:
         model = Person
         fields = ("status",)
@@ -160,7 +161,7 @@ class EnumFieldTest(TestCase):
         request_factory = RequestFactory()
         request = request_factory.post("", data={"status": "2"})
         form = PersonForm(request.POST)
-        self.assertTrue(isinstance(form.fields["status"], TypedChoiceField))
+        self.assertTrue(isinstance(form.fields["status"], forms.TypedChoiceField))
         self.assertTrue(form.is_valid())
         person = form.save()
         self.assertTrue(person.status, PersonStatus.DEAD)
@@ -175,7 +176,7 @@ class EnumFieldTest(TestCase):
         request_factory = RequestFactory()
         request = request_factory.post("", data={"status": "2"})
         form = PersonForm(request.POST, instance=person)
-        self.assertTrue(isinstance(form.fields["status"], TypedChoiceField))
+        self.assertTrue(isinstance(form.fields["status"], forms.TypedChoiceField))
         self.assertTrue(form.is_valid())
         form.save()
         self.assertTrue(person.status, PersonStatus.DEAD)
@@ -194,7 +195,7 @@ class EnumFieldTest(TestCase):
         )
 
     def test_enum_field_nullable_field(self):
-        class BeerForm(ModelForm):
+        class BeerForm(forms.ModelForm):
             class Meta:
                 model = Beer
                 fields = ("style", "state")
@@ -222,6 +223,25 @@ class EnumFieldTest(TestCase):
         call_command("makemigrations", "tests")
         with patch_sqlite_connection():
             call_command("sqlmigrate", "tests", "0001")
+
+    def test_enum_form_field(self):
+        class CustomPersonForm(forms.Form):
+            status = EnumChoiceField(PersonStatus)
+
+        form = CustomPersonForm(initial={"status": PersonStatus.DEAD})
+        self.assertEqual(form["status"].initial, PersonStatus.DEAD.value)
+        self.assertIn(
+            u'<option value="{}" selected'.format(PersonStatus.DEAD.value),
+            six.text_type(form["status"]),
+        )
+        self.assertEqual(form.fields["status"].choices, PersonStatus.choices())
+
+        form = CustomPersonForm(
+            data={"status": six.text_type(PersonStatus.ALIVE.value)},
+            initial={"status": PersonStatus.DEAD.value},
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+        self.assertEqual(form.cleaned_data["status"], PersonStatus.ALIVE)
 
 
 class EnumTest(TestCase):

--- a/django_enumfield/tests/test_enum.py
+++ b/django_enumfield/tests/test_enum.py
@@ -236,6 +236,8 @@ class EnumFieldTest(TestCase):
         )
         self.assertEqual(form.fields["status"].choices, PersonStatus.choices())
 
+        # Test validation
+
         form = CustomPersonForm(
             data={"status": six.text_type(PersonStatus.ALIVE.value)},
             initial={"status": PersonStatus.DEAD.value},
@@ -253,6 +255,7 @@ class EnumFieldTest(TestCase):
         self.assertEqual(
             form.fields["status"].choices, PersonStatus.choices(blank=True)
         )
+        self.assertIn(u'<option value="" selected', six.text_type(form["status"]))
         self.assertTrue(form.is_valid(), form.errors)
         self.assertEqual(form.cleaned_data["status"], six.text_type())
 

--- a/setup.py
+++ b/setup.py
@@ -106,6 +106,13 @@ setup(
         ':python_version=="3.1"': ["enum34"],
         ':python_version=="3.2"': ["enum34"],
         ':python_version=="3.3"': ["enum34"],
-        "dev": ["black", "isort", "Django", "mypy", "django-stubs", "djangorestframework-stubs"],
+        "dev": [
+            "black",
+            "isort",
+            "Django",
+            "mypy",
+            "django-stubs",
+            "djangorestframework-stubs",
+        ],
     },
 )

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist =
     py35-django{111,20,21,22}
     py36-django{111,20,21,22}
     py37-django{20,21,22}
-    coverage
+    checks
 
 [testenv]
 whitelist_externals = make
@@ -16,7 +16,7 @@ deps=
     django22: Django>=2.2,<2.3
 commands = make test
 
-[testenv:coverage]
+[testenv:checks]
 basepython = python3.7
 passenv = TOXENV CI TRAVIS TRAVIS_*
 whitelist_externals = make
@@ -30,8 +30,6 @@ deps =
 setenv =
     COVERALLS_REPO_TOKEN=LdECqqwg7eelQx9w8gvooUZCFIaCqGZCv
 commands =
-    make flake8
-    make mypy
-    make coverage
+    make checks coverage
     coverage report
     coveralls --ignore-errors

--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,7 @@ deps =
     mypy
     django-stubs
     djangorestframework-stubs
+    black
 setenv =
     COVERALLS_REPO_TOKEN=LdECqqwg7eelQx9w8gvooUZCFIaCqGZCv
 commands =


### PR DESCRIPTION
Fixes the saved value not being selected in a form.

Previously the enum was coerced to str and then compared with the int value (`"PersonStats.ALIVE"`), which of course wouldn't match.
To solve this we have to create our own form field which coerces the enum value to its value (int), which is then coerced to a str which is fine.