### PR TITLE
Add default __str__ for Enum

### DIFF
--- a/django_enumfield/enum.py
+++ b/django_enumfield/enum.py
@@ -38,12 +38,16 @@ Default = TypeVar("Default")
 T = TypeVar("T", bound="Enum")
 
 
+@six.python_2_unicode_compatible
 class Enum(NativeIntEnum):
     """ A container for holding and restoring enum values """
 
     __labels__ = {}  # type: Dict[int, six.text_type]
     __default__ = None  # type: Optional[int]
     __transitions__ = {}  # type: Dict[int, Sequence[int]]
+
+    def __str__(self):
+        return self.label
 
     @classdispatcher("get_name")
     def name(self):

--- a/django_enumfield/tests/test_enum.py
+++ b/django_enumfield/tests/test_enum.py
@@ -227,6 +227,12 @@ class EnumTest(TestCase):
             LabelBeer.label(LabelBeer.STELLA), six.text_type("Stella Artois")
         )
 
+        # Same as when coercing to string
+        self.assertEqual(six.text_type(PersonStatus.ALIVE), six.text_type("ALIVE"))
+        self.assertEqual(
+            six.text_type(LabelBeer.STELLA), six.text_type("Stella Artois")
+        )
+
     def test_name(self):
         self.assertEqual(PersonStatus.ALIVE.name, six.text_type("ALIVE"))
         self.assertEqual(LabelBeer.STELLA.name, six.text_type("STELLA"))


### PR DESCRIPTION
Changes the human readable string for the value in form fields. A readable label should be preferred over `EnumName.THING`