### PR TITLE
Add support for Django 3.0b1 and Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ matrix:
       python: 3.8
     - env: ENV=py38-django22
       python: 3.8
-    - env: ENV=py37-django30
+    - env: ENV=py38-django30
       python: 3.8
 
     - env: ENV=checks

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,8 @@ matrix:
       python: 3.6
     - env: ENV=py36-django22
       python: 3.6
+    - env: ENV=py36-django30
+      python: 3.6
 
     - env: ENV=py37-django20
       python: 3.7
@@ -47,6 +49,17 @@ matrix:
       python: 3.7
     - env: ENV=py37-django22
       python: 3.7
+    - env: ENV=py37-django30
+      python: 3.7
+
+    - env: ENV=py38-django20
+      python: 3.8
+    - env: ENV=py38-django21
+      python: 3.8
+    - env: ENV=py38-django22
+      python: 3.8
+    - env: ENV=py37-django30
+      python: 3.8
 
     - env: ENV=checks
       python: 3.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ not found instead of raising `AttributeError`
 Use `Enum.__default__ = VALUE` or pass it explicitly to `EnumField` 
 - Converted README.rst to markdown (README.md)
 - Added Django 2.2 support
+- Added Django 3.0b1 support
 - Dropped support for Django < 1.11
 - Added limited mypy support
 

--- a/django_enumfield/contrib/drf.py
+++ b/django_enumfield/contrib/drf.py
@@ -1,4 +1,4 @@
-from django.utils import six
+import six
 from django.utils.translation import ugettext_lazy as _
 from rest_framework import serializers
 

--- a/django_enumfield/db/fields.py
+++ b/django_enumfield/db/fields.py
@@ -1,17 +1,30 @@
 from enum import Enum
 from functools import partial
+from typing import Any, Callable  # noqa: F401
 
+import six
 from django import forms
 from django.db import models
-from django.utils import six
 from django.utils.encoding import force_text
-from django.utils.functional import curry
 from django.utils.translation import ugettext
 
 from django_enumfield.exceptions import InvalidStatusOperationError
 from django_enumfield.forms.fields import EnumChoiceField
 
 from .. import validators
+
+try:
+    from functools import partialmethod as _partialmethod
+
+    def partialishmethod(method):
+        return _partialmethod(method)
+
+
+except ImportError:
+    from django.utils.functional import curry
+
+    def partialishmethod(method):
+        return curry(method)
 
 
 class EnumField(models.IntegerField):
@@ -42,7 +55,11 @@ class EnumField(models.IntegerField):
     ):
         super(EnumField, self).contribute_to_class(cls, name)
         if self.choices:
-            setattr(cls, "get_%s_display" % self.name, curry(self._get_FIELD_display))
+            setattr(
+                cls,
+                "get_%s_display" % self.name,
+                partialishmethod(self._get_FIELD_display),
+            )
         models.signals.class_prepared.connect(self._setup_validation, sender=cls)
 
     def _get_FIELD_display(self, cls):

--- a/django_enumfield/db/fields.py
+++ b/django_enumfield/db/fields.py
@@ -20,7 +20,7 @@ try:
         return _partialmethod(method)
 
 
-except ImportError:
+except ImportError:  # pragma: no cover
     from django.utils.functional import curry
 
     def partialishmethod(method):

--- a/django_enumfield/enum.py
+++ b/django_enumfield/enum.py
@@ -4,7 +4,7 @@ import logging
 from enum import Enum as NativeEnum, IntEnum as NativeIntEnum
 from typing import Any, Dict, List, Optional, Sequence, Tuple, TypeVar, Union, cast
 
-from django.utils import six
+import six
 from django.utils.decorators import classproperty
 
 from django_enumfield.db.fields import EnumField

--- a/django_enumfield/tests/test_enum.py
+++ b/django_enumfield/tests/test_enum.py
@@ -1,6 +1,7 @@
 from contextlib import contextmanager
 from os.path import abspath, dirname, exists, join
 
+import six
 from django import forms
 from django.core.management import call_command
 from django.db import IntegrityError, connection
@@ -8,7 +9,6 @@ from django.db.backends.sqlite3.base import DatabaseWrapper
 from django.db.models.fields import NOT_PROVIDED
 from django.test import TestCase
 from django.test.client import RequestFactory
-from django.utils import six
 
 from django_enumfield.db.fields import EnumField
 from django_enumfield.enum import BlankEnum, Enum

--- a/django_enumfield/validators.py
+++ b/django_enumfield/validators.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from django.utils import six
+import six
 from django.utils.translation import gettext as _, ugettext
 
 from django_enumfield.exceptions import InvalidStatusOperationError

--- a/run_tests.py
+++ b/run_tests.py
@@ -30,9 +30,15 @@ def main():
     )
     import warnings
 
-    # Ignore deprecation warning caused by Django on 3.7 + 2.0
-    is_py37_django20 = sys.version_info[:2] == (3, 7) and django.VERSION[:2] == (2, 0)
-    module = r"(?!django).*" if is_py37_django20 else ""
+    # Ignore deprecation warning caused by Django on 3.7/3.8 + 2.0/2.1
+    if sys.version_info[:2] in ((3, 7), (3, 8)) and django.VERSION[:2] in (
+        (2, 0),
+        (2, 1),
+    ):
+        module = r"(?!django).*"
+    else:
+        module = ""
+
     warnings.filterwarnings("error", module=module, category=DeprecationWarning)
 
     delete_migrations()

--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,7 @@ setup(
     data_files=data_files,
     packages=packages,
     include_package_data=True,
-    install_requires=['typing;python_version<"3.5"'],
+    install_requires=['typing;python_version<"3.5"', "six>=1.10.0"],
     tests_require=[
         "Django",
         "djangorestframework",

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,9 @@ envlist =
     py27-django111
     py34-django{111,20}
     py35-django{111,20,21,22}
-    py36-django{111,20,21,22}
-    py37-django{20,21,22}
+    py36-django{111,20,21,22,30}
+    py37-django{20,21,22,30}
+    py38-django{20,21,22,30}
     checks
 
 [testenv]
@@ -14,6 +15,7 @@ deps=
     django20: Django>=2.0,<2.1
     django21: Django>=2.1,<2.2
     django22: Django>=2.2,<2.3
+    django30: Django>=3.0b1,<3.1
 commands = make test
 
 [testenv:checks]


### PR DESCRIPTION
- Depend on six instead of using `django.utils.six`
- Use `partialmethod` instead of `django.utils.functional.curry` when available.