### PR TITLE
docs: Fix simple typo, convertable -> convertible

### DIFF
--- a/django_enumfield/tests/test_validators.py
+++ b/django_enumfield/tests/test_validators.py
@@ -9,7 +9,7 @@ from django_enumfield.validators import validate_available_choice
 
 class ValidatorTest(unittest.TestCase):
     def test_validate_available_choice_1(self):
-        """Test passing a value non convertable to an int raises an
+        """Test passing a value non convertible to an int raises an
         InvalidStatusOperationError
         """
         self.assertRaises(


### PR DESCRIPTION
There is a small typo in django_enumfield/tests/test_validators.py.

Should read `convertible` rather than `convertable`.

