### PR TITLE
Remove usage of deprecated functions not supported in Django 4.0

### DIFF
--- a/django_enumfield/db/fields.py
+++ b/django_enumfield/db/fields.py
@@ -5,8 +5,8 @@ from typing import Any, Callable  # noqa: F401
 import six
 from django import forms
 from django.db import models
-from django.utils.encoding import force_text
-from django.utils.translation import ugettext
+from django.utils.encoding import force_str
+from django.utils.translation import gettext
 
 from django_enumfield.exceptions import InvalidStatusOperationError
 from django_enumfield.forms.fields import EnumChoiceField
@@ -66,7 +66,7 @@ class EnumField(models.IntegerField):
         value = getattr(cls, self.attname)
         if value is None:
             return value
-        return force_text(value.label, strings_only=True)
+        return force_str(value.label, strings_only=True)
 
     def get_prep_value(self, value):
         value = super(EnumField, self).get_prep_value(value)
@@ -119,7 +119,7 @@ class EnumField(models.IntegerField):
                     new_value = enum(new_value)
                 except ValueError:
                     raise InvalidStatusOperationError(
-                        ugettext(
+                        gettext(
                             six.text_type(
                                 "{value!r} is not one of the available choices "
                                 "for enum {enum}."


### PR DESCRIPTION
This resolves usage of deprecated functions that have been removed in [Django 4.0](https://docs.djangoproject.com/en/4.0/releases/4.0/)

```
packages/django_enumfield/db/fields.py", line 8, in <module>
71
    from django.utils.encoding import force_text
72
ImportError: cannot import name 'force_text' from 'django.utils.encoding' (
```

@Swamii 