### PR TITLE
Support for Python 3.11 and Django 4.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,7 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         include:
           - python: "3.7"
@@ -30,6 +31,8 @@ jobs:
             tox_env: py38-django32
           - python: "3.8"
             tox_env: py38-django40
+          - python: "3.8"
+            tox_env: py38-django41
           - python: "3.9"
             tox_env: py39-django22
           - python: "3.9"
@@ -40,16 +43,22 @@ jobs:
             tox_env: py39-django32
           - python: "3.9"
             tox_env: py39-django40
+          - python: "3.9"
+            tox_env: py39-django41
           - python: "3.10"
             tox_env: py310-django32
           - python: "3.10"
             tox_env: py310-django40
+          - python: "3.10"
+            tox_env: py310-django41
+          - python: "3.11"
+            tox_env: py311-django41
           - python: "3.7"
             tox_env: checks
     name: ${{ matrix.tox_env }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
       - run: pip install tox

--- a/django_enumfield/db/fields.py
+++ b/django_enumfield/db/fields.py
@@ -15,19 +15,22 @@ from .. import validators
 try:
     from functools import partialmethod as _partialmethod
 
-    def partialishmethod(method):
-        return _partialmethod(method)
+    class partialishmethod(_partialmethod):
+        """Workaround for https://github.com/python/cpython/issues/99152"""
+
+        def __get__(self, obj, cls=None):
+            return self._make_unbound_method().__get__(obj, cls)
 
 except ImportError:  # pragma: no cover
     # This path can be dropped after support for Django 2.2 has been removed.
     from django.utils.functional import curry  # type: ignore[attr-defined]
 
-    def partialishmethod(method):
+    def partialishmethod(method):  # type: ignore[no-redef]
         return curry(method)
 
 
 class EnumField(models.IntegerField):
-    """EnumField is a convenience field to automatically handle validation of transitions
+    """EnumField is a convenience field to automatically handle validation of transition
     between Enum values and set field choices from the enum.
     EnumField(MyEnum, default=MyEnum.INITIAL)
     """

--- a/django_enumfield/enum.py
+++ b/django_enumfield/enum.py
@@ -2,8 +2,22 @@ from __future__ import absolute_import
 
 import logging
 import enum
-from typing import Any, List, Optional, Sequence, Tuple, TypeVar, Union, cast, Mapping
+from typing import (
+    Any,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    TypeVar,
+    Union,
+    cast,
+    Mapping,
+    TYPE_CHECKING,
+)
 from django.utils.encoding import force_str
+
+if TYPE_CHECKING:
+    from django.utils.functional import _StrOrPromise as StrOrPromise
 
 try:
     from django.utils.functional import classproperty  # type: ignore
@@ -47,7 +61,7 @@ T = TypeVar("T", bound="Enum")
 class Enum(enum.IntEnum):
     """A container for holding and restoring enum values"""
 
-    __labels__ = {}  # type: Mapping[int, str]
+    __labels__ = {}  # type: Mapping[int, StrOrPromise]
     __default__ = None  # type: Optional[int]
     __transitions__ = {}  # type: Mapping[int, Sequence[int]]
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,22 +4,23 @@ envlist =
     py38-django{22,30,31,32,40}
     py39-django{22,30,31,32,40}
     py310-django{32,40}
+    py311-django{40,41}
     checks
 
 [testenv]
-whitelist_externals = make
+allowlist_externals = make
 deps=
     django22: Django>=2.2,<2.3
     django30: Django>=3.0b1,<3.1
     django31: Django>=3.1,<3.2
     django32: Django>=3.2,<4.0
     django40: Django>=4.0,<4.1
+    django41: Django>=4.1,<4.2
 commands = make test
 
 [testenv:checks]
 basepython = python3.7
-passenv = TOXENV CI
-whitelist_externals = make
+allowlist_externals = make
 deps =
     Django>=2.2,<2.3
     coverage==4.5.2


### PR DESCRIPTION
Added Python 3.11 and Django 4.1 to the test matrix - currently django-enumfield is failing on Python 3.11 with some mysterious "getattr" errors.

Django 4.1 is passing.

Also, a few minor "modernizations" to run current GitHub actions and latest tox.